### PR TITLE
Add melf-touchscreen.idc into touch support list for Ikura.

### DIFF
--- a/full_inari.mk
+++ b/full_inari.mk
@@ -3,6 +3,7 @@ PRODUCT_COPY_FILES := \
   device/qcom/inari/touchscreen.idc:system/usr/idc/Fts-touchscreen.idc \
   device/qcom/inari/touchscreen.idc:system/usr/idc/atmel-touchscreen.idc \
   device/qcom/inari/touchscreen.idc:system/usr/idc/cyttsp-i2c.idc \
+  device/qcom/inari/touchscreen.idc:system/usr/idc/melf-touchscreen.idc \
   device/qcom/inari/audio.conf:system/etc/bluetooth/audio.conf \
   device/qcom/otoro/media_profiles.xml:system/etc/media_profiles.xml \
   device/qcom/msm7627a/wpa_supplicant.conf:system/etc/wifi/wpa_supplicant.conf


### PR DESCRIPTION
According to bug as below, we need inari to support the touch from ikura because currently inari build is for ikura too.

Bug 909137 - Touchscreen of new ZTE Open doesn't work correctly in Mozilla builds
