### PR TITLE
Include AudioFilter.csv

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -232,7 +232,7 @@ COMMON_ATH6K="
 	"
 copy_files "$COMMON_ATH6K" "system/etc/firmware/ath6k/AR6003/hw2.1.1" "wifi"
 
-COMMON_ETC="init.qcom.bt.sh gps.conf"
+COMMON_ETC="init.qcom.bt.sh gps.conf AudioFilter.csv"
 copy_files "$COMMON_ETC" "system/etc" "etc"
 
 COMMON_EGL="


### PR DESCRIPTION
The file `/etc/AudioFilter.csv` seems to be sought out according to init sequence generated `adb logcat` output (see https://bugzilla.mozilla.org/show_bug.cgi?id=945124).

On the `unagi` device, this is requested. See https://github.com/mozilla-b2g/android-device-unagi/blob/master/extract-files.sh#L241

If this looks non-insane, you should probably add it. OTOH, it might be insane -  can't see why everyone else would miss this for months. But others reported the same issue on #b2g IRC as per the above URL...
